### PR TITLE
Hotfix - eliminar usuario

### DIFF
--- a/src/main/java/com/magicdogs/alkywall/config/SecurityConfig.java
+++ b/src/main/java/com/magicdogs/alkywall/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
                         .requestMatchers("/api-docs").permitAll()
                         .requestMatchers("/api/**").permitAll()
                         .requestMatchers("/api-docs/swagger-config").permitAll()
-                        .requestMatchers("/users/**").hasRole("ADMIN")
+                        .requestMatchers("/users").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/magicdogs/alkywall/controllers/UserController.java
+++ b/src/main/java/com/magicdogs/alkywall/controllers/UserController.java
@@ -1,9 +1,11 @@
 package com.magicdogs.alkywall.controllers;
 
 import com.magicdogs.alkywall.dto.UserDto;
+import com.magicdogs.alkywall.servicies.JWTService;
 import com.magicdogs.alkywall.servicies.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private JWTService jwtService;
 
     @Operation(summary = "Obtener lista de usuarios")
     @GetMapping("")
@@ -27,8 +30,10 @@ public class UserController {
 
     @Operation(summary = "Eliminar usuario por ID")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Object> userDelete(@PathVariable("id") Long id){
-        userService.softDeleteUser(id);
+    public ResponseEntity<Object> userDelete(@PathVariable("id") Long id, HttpServletRequest request){
+        var token = jwtService.getJwtFromCookies(request);
+        var userEmail = jwtService.extractUserId(token);
+        userService.softDeleteUser(id, userEmail);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 }

--- a/src/main/java/com/magicdogs/alkywall/servicies/UserService.java
+++ b/src/main/java/com/magicdogs/alkywall/servicies/UserService.java
@@ -1,7 +1,10 @@
 package com.magicdogs.alkywall.servicies;
 
+import com.magicdogs.alkywall.entities.RoleNameEnum;
+import com.magicdogs.alkywall.exceptions.ApiException;
 import com.magicdogs.alkywall.repositories.UserRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -9,6 +12,7 @@ import org.springframework.stereotype.Component;import com.magicdogs.alkywall.co
 import com.magicdogs.alkywall.dto.UserDto;
 import com.magicdogs.alkywall.entities.User;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -32,9 +36,18 @@ public class UserService implements UserDetailsService {
      * (1: baja, 0: activo)
      * @param id
      */
-    public void softDeleteUser(Long id){
-        Optional<User> user = userRepository.findById(id);
-        user.ifPresent(value -> value.setSoftDelete(1));
-        userRepository.save(user.get());
+    public void softDeleteUser(Long id, String userEmail) {
+        var user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Usuario no encontrado"));
+
+        boolean isAdmin = user.getRole().getName() == RoleNameEnum.ADMIN;
+        boolean isSameUser = Objects.equals(user.getIdUser(), id);
+
+        if (!isAdmin && !isSameUser) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "No se puede eliminar el usuario porque no tiene permiso de administrador");
+        }
+
+        user.setSoftDelete(1);
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
Eliminar usuario solo estaba disponible para usuarios con el rol ADMIN. Lo que se pedía era: "Sólo podrá ser dado de baja mi usuario, a menos que el usuario loggeado sea ADMINISTRADOR, en ese caso podría dar de baja cualquiera." Con los cambios un usuario comun puede darse de baja a si mismo y un usuario administrado a cualquier otro usuario.